### PR TITLE
Remove excessive exclamation marks

### DIFF
--- a/src/quickie/runner.clj
+++ b/src/quickie/runner.clj
@@ -49,7 +49,7 @@
   (-> (:output result)
       last
       println)
-  (println (clansi/style "   All Tests Passing!!!!   " :black :bg-green)))
+  (println (clansi/style "   All Tests Passing!   " :black :bg-green)))
 
 (defn print-fail [result]
   (let [{:keys [error fail]} (:result result)


### PR DESCRIPTION
I hope you'll forgive me for the extremely pernickety and passive aggressive edit, but those four exclamation marks are driving me mad and I don't want to maintain a fork just for people with grammar OCD. I've left one in as a compromise. :)
