### PR TITLE
Fix for ArityException when running lein quickie

### DIFF
--- a/src/quickie/runner.clj
+++ b/src/quickie/runner.clj
@@ -198,7 +198,7 @@
     (try
     (let [matcher (:test-matcher project #"test")
           result  (out-str-result (partial test/run-all-tests matcher))]
-      (print-ns-result result))
+      (print-result result))
     (catch Exception e 
       (println (.getMessage e))
       (.printStackTrace e))))


### PR DESCRIPTION
After 4e42f5c155e6c07ddbc3869640c194365865cf9e change lein quickie stopped working. It always gives me:

clojure.lang.ArityException: Wrong number of args (1) passed to: runner/print-ns-result
    at clojure.lang.AFn.throwArity(AFn.java:429)
    at clojure.lang.AFn.invoke(AFn.java:32)
    at quickie.runner$run.invoke(runner.clj:201)
    at quickie.autotest$run.invoke(autotest.clj:55)
    at user$eval848.invoke(form-init1759189944514376690.clj:1)
    at clojure.lang.Compiler.eval(Compiler.java:6703)
    at clojure.lang.Compiler.eval(Compiler.java:6693)
    at clojure.lang.Compiler.load(Compiler.java:7130)
    at clojure.lang.Compiler.loadFile(Compiler.java:7086)
    at clojure.main$load_script.invoke(main.clj:274)
    at clojure.main$init_opt.invoke(main.clj:279)
    at clojure.main$initialize.invoke(main.clj:307)
    at clojure.main$null_opt.invoke(main.clj:342)
    at clojure.main$main.doInvoke(main.clj:420)
    at clojure.lang.RestFn.invoke(RestFn.java:421)
    at clojure.lang.Var.invoke(Var.java:383)
    at clojure.lang.AFn.applyToHelper(AFn.java:156)
    at clojure.lang.Var.applyTo(Var.java:700)
    at clojure.main.main(main.java:37)
